### PR TITLE
Add max depth level var

### DIFF
--- a/downloadSite.sh
+++ b/downloadSite.sh
@@ -8,7 +8,7 @@
 usage() { echo "Usage: $0 [-s <site-shortname>] | [-f <folder>]" 1>&2; exit 1; }
 
 # Command line options
-while getopts "u:p:he:s:f:" o; do
+while getopts "u:p:he:s:f:l:" o; do
     case "${o}" in
         u)
             MYUSER=${OPTARG}
@@ -24,6 +24,9 @@ while getopts "u:p:he:s:f:" o; do
             ;;
         f)
             FOLDER=${OPTARG}
+            ;;
+        l)
+            MAXDEPTHLEVEL=${OPTARG}
             ;;
         \?)
             echo "Invalid Option: -$OPTARG" 1>&2
@@ -51,6 +54,11 @@ if [ -z "${SITE}" ] && [ -z "${FOLDER}" ] ; then
     usage
 fi
 
+# Needs at least default max depth level param
+if [ -z "${MAXDEPTHLEVEL}" ]; then
+    usage
+fi
+
 # Default parameters
 #ALFURL=${ALFURL:-http://localhost:8080/alfresco}
 #MYUSER=${MYUSER:-admin}
@@ -59,7 +67,7 @@ fi
 
 if [ -n "${SITE}" ]; then
   #wget -r -nH -np -nv --cut-dirs=1 --user=$MYUSER --password=$MYPASS "$ALFURL/webdav/Sitios/$SITE/documentLibrary"
-  wget -r -nH -np -nv --cut-dirs=1 --user=$MYUSER --password=$MYPASS "$ALFURL/webdav/Sites/$SITE/documentLibrary"
+  wget -r -nH -np -nv --level=$MAXDEPTHLEVEL --cut-dirs=1 --user=$MYUSER --password=$MYPASS "$ALFURL/webdav/Sites/$SITE/documentLibrary"
 else
-  wget -r -nH -np -nv --cut-dirs=1 --user=$MYUSER --password=$MYPASS "$ALFURL/webdav/$FOLDER"
+  wget -r -nH -np -nv --level=$MAXDEPTHLEVEL --cut-dirs=1 --user=$MYUSER --password=$MYPASS "$ALFURL/webdav/$FOLDER"
 fi

--- a/exportENVARS.sh
+++ b/exportENVARS.sh
@@ -6,3 +6,4 @@
 export ALFURL=http://melmac.zylk.net:8080/alfresco
 export MYUSER=admin
 export MYPASS=zylk
+export MAXDEPTHLEVEL=5


### PR DESCRIPTION
Default max depth level is 5 when using wget recursive mode.
On big sites or file plans, all nodes are not retrieved and anything below level 5 is skipped.